### PR TITLE
Minor optimization of ComponentAccessor.

### DIFF
--- a/component/src/main/java/com/linecorp/lich/component/ComponentFactory.kt
+++ b/component/src/main/java/com/linecorp/lich/component/ComponentFactory.kt
@@ -216,30 +216,28 @@ abstract class ComponentFactory<T : Any> {
     @Volatile
     private var component: Any? = null
 
-    internal companion object {
+    internal object Accessor : ComponentAccessor {
         private val fieldUpdater = AtomicReferenceFieldUpdater.newUpdater(
             ComponentFactory::class.java,
             Any::class.java,
             "component"
         )
 
-        internal val accessor: ComponentAccessor = object : ComponentAccessor {
-            override fun <T : Any> createComponent(
-                factory: ComponentFactory<T>,
-                applicationContext: Context
-            ): T = factory.createComponent(applicationContext)
+        override fun <T : Any> createComponent(
+            factory: ComponentFactory<T>,
+            applicationContext: Context
+        ): T = factory.createComponent(applicationContext)
 
-            override fun getComponent(factory: ComponentFactory<*>): Any? = factory.component
+        override fun getComponent(factory: ComponentFactory<*>): Any? = factory.component
 
-            override fun setComponent(factory: ComponentFactory<*>, component: Any?) {
-                factory.component = component
-            }
-
-            override fun compareAndSetComponent(
-                factory: ComponentFactory<*>,
-                expect: Any?,
-                update: Any?
-            ): Boolean = fieldUpdater.compareAndSet(factory, expect, update)
+        override fun setComponent(factory: ComponentFactory<*>, component: Any?) {
+            factory.component = component
         }
+
+        override fun compareAndSetComponent(
+            factory: ComponentFactory<*>,
+            expect: Any?,
+            update: Any?
+        ): Boolean = fieldUpdater.compareAndSet(factory, expect, update)
     }
 }

--- a/component/src/main/java/com/linecorp/lich/component/internal/ComponentProvider.kt
+++ b/component/src/main/java/com/linecorp/lich/component/internal/ComponentProvider.kt
@@ -47,7 +47,7 @@ internal val componentProvider: ComponentProvider =
             ComponentProvider::class.java,
             ComponentProvider::class.java.classLoader
         ).iterator()
-    }.maxBy { it.loadPriority }?.apply { init(ComponentFactory.accessor) }
+    }.maxBy { it.loadPriority }?.apply { init(ComponentFactory.Accessor) }
         ?: throw Error("Failed to load ComponentProvider.")
 
 fun getComponentManager(applicationContext: Context): Any =

--- a/component/src/main/java/com/linecorp/lich/component/internal/DefaultComponentProvider.kt
+++ b/component/src/main/java/com/linecorp/lich/component/internal/DefaultComponentProvider.kt
@@ -31,7 +31,7 @@ internal class DefaultComponentProvider : ComponentProvider {
     override fun init(accessor: ComponentAccessor) = Unit
 
     override fun <T : Any> getComponent(context: Context, factory: ComponentFactory<T>): T {
-        val accessor = ComponentFactory.accessor
+        val accessor = ComponentFactory.Accessor
         accessor.getComponent(factory)?.let {
             @Suppress("UNCHECKED_CAST")
             return if (it is Creating) it.await() else it as T


### PR DESCRIPTION
Use an object declaration instead of an object expression in the companion object.