### PR TITLE
Use LifecycleEventObserver instead of DefaultLifecycleObserver.

### DIFF
--- a/lifecycle/build.gradle
+++ b/lifecycle/build.gradle
@@ -23,7 +23,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.kotlinCoroutines}"
-    implementation "androidx.lifecycle:lifecycle-common-java8:${versions.androidxLifecycle}"
+    implementation "androidx.lifecycle:lifecycle-common:${versions.androidxLifecycle}"
 
     androidTestImplementation "androidx.fragment:fragment:${versions.androidxFragment}"
     androidTestImplementation "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlin}"

--- a/lifecycle/build.gradle
+++ b/lifecycle/build.gradle
@@ -13,11 +13,6 @@ android {
         targetSdkVersion versions.targetSdk
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
 }
 
 dependencies {

--- a/sample_app/build.gradle
+++ b/sample_app/build.gradle
@@ -25,11 +25,6 @@ android {
         }
     }
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     dataBinding {
         enabled = true
     }

--- a/sample_feature/build.gradle
+++ b/sample_feature/build.gradle
@@ -8,11 +8,6 @@ android {
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
     }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
 }
 
 dependencies {


### PR DESCRIPTION
Now, we can use lifecycle-common instead of lifecycle-common-java8.