### PR TITLE
Remove deprecated 1-arg createViewModel().

### DIFF
--- a/viewmodel/src/main/java/com/linecorp/lich/viewmodel/ViewModelFactory.kt
+++ b/viewmodel/src/main/java/com/linecorp/lich/viewmodel/ViewModelFactory.kt
@@ -84,18 +84,7 @@ abstract class ViewModelFactory<T : AbstractViewModel> {
      * @param savedState a handle to saved state.
      */
     @MainThread
-    protected open fun createViewModel(context: Context, savedState: SavedState): T {
-        @Suppress("DEPRECATION")
-        return createViewModel(context)
-    }
-
-    @Deprecated(
-        message = "Only for backward compatibility. Will be removed in 2.1.0",
-        replaceWith = ReplaceWith("createViewModel(context, handle)")
-    )
-    protected open fun createViewModel(context: Context): T {
-        throw NotImplementedError()
-    }
+    protected abstract fun createViewModel(context: Context, savedState: SavedState): T
 
     internal fun create(context: Context, savedState: SavedState): T =
         createViewModel(context, savedState)


### PR DESCRIPTION
Binary compatibility with 1.x was already broken for `ViewModelLazy.kt`.
So, we don't need to care about the backward compatibility.