### PR TITLE
Factory detector

### DIFF
--- a/component/build.gradle
+++ b/component/build.gradle
@@ -31,6 +31,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
     compileOnly "androidx.fragment:fragment:${versions.androidxFragment}"
+    lintPublish project(':static-analysis')
 
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlin}"
     testImplementation "androidx.test:runner:${versions.androidxTestRunner}"

--- a/static-analysis/src/main/java/com/linecorp/lich/static_analysis/LichIssueRegistry.kt
+++ b/static-analysis/src/main/java/com/linecorp/lich/static_analysis/LichIssueRegistry.kt
@@ -3,27 +3,20 @@ package com.linecorp.lich.static_analysis
 import com.android.tools.lint.client.api.IssueRegistry
 import com.android.tools.lint.detector.api.CURRENT_API
 import com.android.tools.lint.detector.api.Issue
-import com.linecorp.lich.static_analysis.detectors.OptionalArgumentRequiredDetector
 import com.google.auto.service.AutoService
 import com.linecorp.lich.static_analysis.detectors.LichFactoryDetector
+import com.linecorp.lich.static_analysis.detectors.OptionalArgumentRequiredDetector
 
 /**
  * A class to register custom [Issue]s
  */
 @AutoService(IssueRegistry::class)
 class LichIssueRegistry : IssueRegistry() {
-    override val issues: List<Issue>
-        get() = listOf(
-            OptionalArgumentRequiredDetector.ISSUE,
-            LichFactoryDetector.TYPE_ARGUMENT_ISSUE,
-            LichFactoryDetector.OBJECT_ISSUE
-        )
+    override val issues: List<Issue> = listOf(
+        OptionalArgumentRequiredDetector.ISSUE,
+        LichFactoryDetector.TYPE_ARGUMENT_ISSUE,
+        LichFactoryDetector.OBJECT_ISSUE
+    )
 
     override val api: Int = CURRENT_API
-
-    override val minApi: Int = MIN_API
-
-    companion object {
-        const val MIN_API = 2 // Corresponds to android gradle plugin 3.2+
-    }
 }

--- a/static-analysis/src/main/java/com/linecorp/lich/static_analysis/LichIssueRegistry.kt
+++ b/static-analysis/src/main/java/com/linecorp/lich/static_analysis/LichIssueRegistry.kt
@@ -5,6 +5,7 @@ import com.android.tools.lint.detector.api.CURRENT_API
 import com.android.tools.lint.detector.api.Issue
 import com.linecorp.lich.static_analysis.detectors.OptionalArgumentRequiredDetector
 import com.google.auto.service.AutoService
+import com.linecorp.lich.static_analysis.detectors.LichFactoryDetector
 
 /**
  * A class to register custom [Issue]s
@@ -12,7 +13,11 @@ import com.google.auto.service.AutoService
 @AutoService(IssueRegistry::class)
 class LichIssueRegistry : IssueRegistry() {
     override val issues: List<Issue>
-        get() = listOf(OptionalArgumentRequiredDetector.ISSUE)
+        get() = listOf(
+            OptionalArgumentRequiredDetector.ISSUE,
+            LichFactoryDetector.TYPE_ARGUMENT_ISSUE,
+            LichFactoryDetector.OBJECT_ISSUE
+        )
 
     override val api: Int = CURRENT_API
 

--- a/static-analysis/src/main/java/com/linecorp/lich/static_analysis/detectors/LichFactoryDetector.kt
+++ b/static-analysis/src/main/java/com/linecorp/lich/static_analysis/detectors/LichFactoryDetector.kt
@@ -1,0 +1,153 @@
+package com.linecorp.lich.static_analysis.detectors
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.LintFix
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.isKotlin
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.impl.source.PsiClassReferenceType
+import com.linecorp.lich.static_analysis.extensions.findClosestParentByType
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.psiUtil.isAbstract
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UTypeReferenceExpression
+
+/**
+ * A detector to find possible misuses of Lich component factories.
+ */
+class LichFactoryDetector : Detector(), SourceCodeScanner {
+    companion object {
+        @JvmStatic
+        val TYPE_ARGUMENT_ISSUE: Issue = Issue.create(
+            "InvalidTypeArgumentInFactory",
+            "The factory's type argument should be the companion object's parent class.",
+            "Factories in companion objects should never create instances of classes outside of " +
+                "the scope of the companion object's parent class. Change the type argument of " +
+                "this factory to the companion object's parent class or use a top level *object* " +
+                "declaration instead.",
+            Category.CORRECTNESS,
+            6,
+            Severity.ERROR,
+            Implementation(LichFactoryDetector::class.java, Scope.JAVA_FILE_SCOPE)
+        )
+        @JvmStatic
+        val OBJECT_ISSUE: Issue = Issue.create(
+            "FactoryShouldBeObject",
+            "It is better practice to implement factories using an *object* declaration.",
+            "Factories should be implemented by *object* declarations in order to avoid multiple " +
+                "instances of the same factory.",
+            Category.CORRECTNESS,
+            6,
+            Severity.WARNING,
+            Implementation(LichFactoryDetector::class.java, Scope.JAVA_FILE_SCOPE)
+        )
+    }
+
+    override fun applicableSuperClasses(): List<String> = Factory.qualifiedNames
+
+    override fun visitClass(context: JavaContext, declaration: UClass) {
+        if (!isKotlin(declaration)) {
+            return
+        }
+        val declarationPsi = declaration.sourcePsi
+        if (declarationPsi !is KtObjectDeclaration) {
+            if (declarationPsi is KtClass && !declarationPsi.isAbstract()) {
+                context.reportObject(declaration)
+            }
+        }
+        val factorySupertypeDeclaration = declaration.findFactorySupertype() ?: return
+        val factoryType = Factory.find(factorySupertypeDeclaration.getQualifiedName()) ?: return
+        val parentClass = declaration.findClosestParentByType<UClass>() ?: return
+        val typeArgument = factorySupertypeDeclaration.typeArgument
+        val typeArgumentCanonical = typeArgument?.canonicalText.orEmpty()
+        if (parentClass.qualifiedName != typeArgumentCanonical) {
+            context.reportTypeArgument(factorySupertypeDeclaration, parentClass, factoryType)
+        }
+    }
+
+    /**
+     * Finds the Lich factory super class among the analyzed class' super types:
+     *
+     * ```
+     *     // snip...
+     *
+     *     companion object : FooInterface, ViewModelFactory<FooViewModel>() {
+     *         override fun createViewModel(context: Context, savedState: SavedState): FooViewModel =
+     *             FooViewModel(context, savedState)
+     *     }
+     * ```
+     * In this case, we are only interested in [ViewModelFactory] even though the companion object
+     * is inheriting from several interfaces/classes.
+     *
+     * Note: there is a limitation with the current implementation. If the companion object is
+     * implementing both [ViewModelFactory] and [ComponentFactory] it will only report the first
+     * one.
+     */
+    private fun UClass.findFactorySupertype(): UTypeReferenceExpression? =
+        this.uastSuperTypes.find { superClass -> Factory.contains(superClass.getQualifiedName()) }
+
+    /**
+     * Returns the type argument, if any, of the provided class reference.
+     */
+    private val UTypeReferenceExpression.typeArgument: PsiClassReferenceType?
+        get() = (type as? PsiClassType)?.typeArguments()?.first() as? PsiClassReferenceType
+
+    private fun JavaContext.reportTypeArgument(
+        node: UElement,
+        parentClass: UClass,
+        factory: Factory
+    ) {
+        // Provides a quick fix to replace the type argument with the correct class name.
+        val fix: LintFix = LintFix.create().replace()
+            .name("Replace ${factory.shortName}'s type argument with ${parentClass.name}")
+            .with("${factory.shortName}<${parentClass.name}>")
+            .reformat(true)
+            .shortenNames()
+            .build()
+
+        report(
+            TYPE_ARGUMENT_ISSUE,
+            node,
+            getNameLocation(node),
+            "This ${factory.shortName}'s type argument should be ${parentClass.name}.",
+            fix
+        )
+    }
+
+    private fun JavaContext.reportObject(node: UElement) {
+        report(
+            OBJECT_ISSUE,
+            node,
+            getNameLocation(node),
+            "Factories generally should be implemented by *object* declarations."
+        )
+    }
+
+    /**
+     * An enum representing the different types of factories provided by Lich.
+     *
+     * @property qualifiedName holds the fully qualified name of the the factory.
+     * @property shortName holds the abbreviated name of the factory.
+     */
+    private enum class Factory(val qualifiedName: String, val shortName: String) {
+        VIEWMODEL("com.linecorp.lich.viewmodel.ViewModelFactory", "ViewModelFactory"),
+        COMPONENT("com.linecorp.lich.component.ComponentFactory", "ComponentFactory");
+
+        companion object {
+            val qualifiedNames: List<String> = values().map { it.qualifiedName }
+
+            fun contains(qualifiedName: String?): Boolean = qualifiedNames.contains(qualifiedName)
+
+            fun find(qualifiedName: String?): Factory? =
+                values().find { it.qualifiedName == qualifiedName }
+        }
+    }
+}

--- a/static-analysis/src/test/java/com/linecorp/lich/static_analysis/LichFactoryDetectorTest.kt
+++ b/static-analysis/src/test/java/com/linecorp/lich/static_analysis/LichFactoryDetectorTest.kt
@@ -1,0 +1,57 @@
+package com.linecorp.lich.static_analysis
+
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import com.linecorp.lich.static_analysis.detectors.LichFactoryDetector
+
+class LichFactoryDetectorTest : LichLintDetectorTest(testAssetsFolder = "LichFactoryDetector") {
+
+    fun testComponentFactory() {
+        val dependencies = assetsFolder.getContent("ComponentFactoryDependencies.kt")
+        val componentFactoryTest = assetsFolder.getContent("ComponentFactoryTest.kt")
+
+        lint().files(
+            kotlin(dependencies),
+            kotlin(componentFactoryTest)
+        ).allowCompilationErrors(false)
+            .run()
+            .expect("""
+                src/com/linecorp/lich/component/ClassFactory.kt:5: Warning: Factories generally should be implemented by object declarations. [FactoryShouldBeObject]
+                class ClassFactory : ComponentFactory<ClassFactory>()
+                      ~~~~~~~~~~~~
+                src/com/linecorp/lich/component/ClassFactory.kt:18: Error: This ComponentFactory's type argument should be TestBar. [InvalidTypeArgumentInFactory]
+                    companion object : ComponentFactory<TestFoo>()
+                                       ~~~~~~~~~~~~~~~~~~~~~~~~~
+                1 errors, 1 warnings
+            """.trimIndent())
+    }
+
+    fun testViewModelFactory() {
+        val dependencies = assetsFolder.getContent("ViewModelFactoryDependencies.kt")
+        val viewModelFactoryTest = assetsFolder.getContent("ViewModelFactoryTest.kt")
+
+        lint().files(
+            kotlin(dependencies),
+            kotlin(viewModelFactoryTest)
+        ).allowCompilationErrors(false)
+            .run()
+            .expect("""
+                src/com/linecorp/lich/viewmodel/TestFoo.kt:15: Warning: Factories generally should be implemented by object declarations. [FactoryShouldBeObject]
+                class ClassFactory : ViewModelFactory<ClassFactory>()
+                      ~~~~~~~~~~~~
+                src/com/linecorp/lich/viewmodel/TestFoo.kt:10: Error: This ViewModelFactory's type argument should be TestBar. [InvalidTypeArgumentInFactory]
+                    companion object : ViewModelFactory<TestFoo>()
+                                       ~~~~~~~~~~~~~~~~~~~~~~~~~
+                1 errors, 1 warnings
+            """.trimIndent())
+    }
+
+    override fun getDetector(): Detector = LichFactoryDetector()
+
+    override fun getIssues(): MutableList<Issue> {
+        return mutableListOf(
+            LichFactoryDetector.TYPE_ARGUMENT_ISSUE,
+            LichFactoryDetector.OBJECT_ISSUE
+        )
+    }
+}

--- a/static-analysis/src/test/java/com/linecorp/lich/static_analysis/LichLintDetectorTest.kt
+++ b/static-analysis/src/test/java/com/linecorp/lich/static_analysis/LichLintDetectorTest.kt
@@ -1,0 +1,15 @@
+package com.linecorp.lich.static_analysis
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest
+import java.io.File
+
+/**
+ * A class to simplify access to test assets.
+ */
+abstract class LichLintDetectorTest(testAssetsFolder: String) : LintDetectorTest() {
+    protected val assetsFolder = File("src/test/test-assets/$testAssetsFolder")
+
+    protected fun File.getContent(filename: String): String {
+        return File(this, filename).readText()
+    }
+}

--- a/static-analysis/src/test/java/com/linecorp/lich/static_analysis/OptionalArgumentRequiredDetectorTest.kt
+++ b/static-analysis/src/test/java/com/linecorp/lich/static_analysis/OptionalArgumentRequiredDetectorTest.kt
@@ -1,19 +1,17 @@
 package com.linecorp.lich.static_analysis
 
-import com.android.tools.lint.checks.infrastructure.LintDetectorTest
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Issue
 import com.linecorp.lich.static_analysis.detectors.OptionalArgumentRequiredDetector
-import java.io.File
-import java.nio.file.Files
-import java.nio.file.Paths
 
-class OptionalArgumentRequiredDetectorTest : LintDetectorTest() {
+class OptionalArgumentRequiredDetectorTest :
+    LichLintDetectorTest(testAssetsFolder = "OptionalArgumentRequiredDetector") {
+
     private val argumentDependencies =
-        getContent(TEST_DIR, "ViewModelArgumentDependencies.kt")
+        assetsFolder.getContent("ViewModelArgumentDependencies.kt")
 
     fun testViewModelArgumentsNoWarnings() {
-        val noErrorsTest = getContent(TEST_DIR, "ViewModelOptionalArgumentTestNoWarnings.kt")
+        val noErrorsTest = assetsFolder.getContent("ViewModelOptionalArgumentTestNoWarnings.kt")
 
         lint().files(
             kotlin(argumentDependencies),
@@ -24,8 +22,7 @@ class OptionalArgumentRequiredDetectorTest : LintDetectorTest() {
     }
 
     fun testViewModelArgumentsShowWarnings() {
-        val testWithErrors =
-            getContent(TEST_DIR, filename = "ViewModelOptionalArgumentTestShowsError.kt")
+        val testWithErrors = assetsFolder.getContent("ViewModelOptionalArgumentTestShowsError.kt")
 
         lint().files(
             kotlin(argumentDependencies),
@@ -45,15 +42,5 @@ class OptionalArgumentRequiredDetectorTest : LintDetectorTest() {
 
     override fun getIssues(): MutableList<Issue> {
         return mutableListOf(OptionalArgumentRequiredDetector.ISSUE)
-    }
-
-    private fun getContent(dir: File, filename: String): String {
-        return String(
-            Files.readAllBytes(Paths.get(File(dir, filename).toURI()))
-        )
-    }
-
-    companion object {
-        private val TEST_DIR = File("src/test/test-assets/OptionalArgumentRequiredDetector")
     }
 }

--- a/static-analysis/src/test/test-assets/LichFactoryDetector/ComponentFactoryDependencies.kt
+++ b/static-analysis/src/test/test-assets/LichFactoryDetector/ComponentFactoryDependencies.kt
@@ -1,0 +1,3 @@
+package com.linecorp.lich.component
+
+abstract class ComponentFactory<T : Any>

--- a/static-analysis/src/test/test-assets/LichFactoryDetector/ComponentFactoryTest.kt
+++ b/static-analysis/src/test/test-assets/LichFactoryDetector/ComponentFactoryTest.kt
@@ -1,0 +1,19 @@
+package com.linecorp.lich.component
+
+// This should show a warning because a class is implementing a factory instead of an object
+// declaration.
+class ClassFactory : ComponentFactory<ClassFactory>()
+
+// This is correct (lint shouldn't report this line) because an object declaration is
+// implementing the factory.
+object ObjectFactory : ComponentFactory<ClassFactory>()
+
+class TestFoo : ComponentFactory() {
+    // This should be correct (lint shoudn't report this line)
+    companion object : ComponentFactory<TestFoo>()
+}
+
+class TestBar : ComponentFactory() {
+    // This should be wrong because TestBar's factory is creating TestFoo objects.
+    companion object : ComponentFactory<TestFoo>()
+}

--- a/static-analysis/src/test/test-assets/LichFactoryDetector/ViewModelFactoryDependencies.kt
+++ b/static-analysis/src/test/test-assets/LichFactoryDetector/ViewModelFactoryDependencies.kt
@@ -1,0 +1,5 @@
+package com.linecorp.lich.viewmodel
+
+abstract class AbstractViewModel
+
+abstract class ViewModelFactory<T : AbstractViewModel>

--- a/static-analysis/src/test/test-assets/LichFactoryDetector/ViewModelFactoryTest.kt
+++ b/static-analysis/src/test/test-assets/LichFactoryDetector/ViewModelFactoryTest.kt
@@ -1,0 +1,19 @@
+package com.linecorp.lich.viewmodel
+
+class TestFoo : AbstractViewModel() {
+    // This should be correct (lint shoudn't report this line)
+    companion object : ViewModelFactory<TestFoo>()
+}
+
+class TestBar : AbstractViewModel() {
+    // This should be wrong because TestBar's factory is creating TestFoo objects.
+    companion object : ViewModelFactory<TestFoo>()
+}
+
+// This should show a warning because a class is implementing a factory instead of an object
+// declaration.
+class ClassFactory : ViewModelFactory<ClassFactory>()
+
+// This is correct (lint shouldn't report this line) because an object declaration is
+// implementing the factory.
+object ObjecFactory : ViewModelFactory<ClassFactory>()


### PR DESCRIPTION
Adds a source code detector to find misuses of Lich factories. The detector detects the following misusages:
- Companion objects providing factories of objects outside of the scope of the companion object's parent class.
- Shows a warning when a factory is implemented by a class to avoid multiple instances of the same factory.

The implementation has a limitation when an object implements both `ViewModelFactory` and `ComponentFactory`. For now, I'm not handling that scenario but it shouldn't be difficult to add it if necessary.