### PR TITLE
Improve error messages of viewmodel-compiler.

### DIFF
--- a/viewmodel-compiler/src/main/java/com/linecorp/lich/viewmodel/compiler/ViewModelArgsProcessor.kt
+++ b/viewmodel-compiler/src/main/java/com/linecorp/lich/viewmodel/compiler/ViewModelArgsProcessor.kt
@@ -34,7 +34,7 @@ class ViewModelArgsProcessor : AbstractProcessor() {
             for (element in roundEnv.getElementsAnnotatedWith(annotation)) {
                 if (element !is TypeElement || element.nestingKind != NestingKind.TOP_LEVEL) {
                     processingEnv.messager.printMessage(
-                        Diagnostic.Kind.WARNING,
+                        Diagnostic.Kind.ERROR,
                         "@GenerateArgs supports top-level classes only.",
                         element
                     )
@@ -49,26 +49,26 @@ class ViewModelArgsProcessor : AbstractProcessor() {
                     )
                 } catch (e: Exception) {
                     processingEnv.messager.printMessage(
-                        Diagnostic.Kind.WARNING,
+                        Diagnostic.Kind.ERROR,
                         "Failed to parse the metadata: $e",
                         element
                     )
                     continue
                 }
 
-                viewModelArgsInfo.errorMessages.forEach { errorMessage ->
-                    processingEnv.messager.printMessage(
-                        Diagnostic.Kind.WARNING,
-                        errorMessage,
-                        element
-                    )
-                }
                 try {
                     viewModelArgsInfo.toFileSpec().writeTo(processingEnv.filer)
                 } catch (e: Exception) {
                     processingEnv.messager.printMessage(
                         Diagnostic.Kind.ERROR,
                         "Failed to generate the Args file: $e"
+                    )
+                }
+                viewModelArgsInfo.errorMessages.forEach { errorMessage ->
+                    processingEnv.messager.printMessage(
+                        Diagnostic.Kind.ERROR,
+                        errorMessage,
+                        element
                     )
                 }
             }

--- a/viewmodel-compiler/src/main/java/com/linecorp/lich/viewmodel/compiler/ViewModelArgsProcessor.kt
+++ b/viewmodel-compiler/src/main/java/com/linecorp/lich/viewmodel/compiler/ViewModelArgsProcessor.kt
@@ -42,7 +42,11 @@ class ViewModelArgsProcessor : AbstractProcessor() {
                 }
 
                 val viewModelArgsInfo = try {
-                    ViewModelArgsInfo.create(element)
+                    ViewModelArgsInfo.create(
+                        element,
+                        processingEnv.elementUtils,
+                        processingEnv.typeUtils
+                    )
                 } catch (e: Exception) {
                     processingEnv.messager.printMessage(
                         Diagnostic.Kind.WARNING,
@@ -51,19 +55,16 @@ class ViewModelArgsProcessor : AbstractProcessor() {
                     )
                     continue
                 }
-                for (propertyName in viewModelArgsInfo.failedProperties) {
+
+                viewModelArgsInfo.errorMessages.forEach { errorMessage ->
                     processingEnv.messager.printMessage(
                         Diagnostic.Kind.WARNING,
-                        "Failed to resolve the type of a property: $propertyName",
+                        errorMessage,
                         element
                     )
                 }
-
                 try {
-                    viewModelArgsInfo.toFileSpec(
-                        processingEnv.elementUtils,
-                        processingEnv.typeUtils
-                    ).writeTo(processingEnv.filer)
+                    viewModelArgsInfo.toFileSpec().writeTo(processingEnv.filer)
                 } catch (e: Exception) {
                     processingEnv.messager.printMessage(
                         Diagnostic.Kind.ERROR,


### PR DESCRIPTION
`ViewModelArgsProcessor` reports detailed errors for unsupported types.