### PR TITLE
Check ViewModelFactory is not a local or anonymous class.

### DIFF
--- a/viewmodel/src/main/java/com/linecorp/lich/viewmodel/internal/DefaultLichViewModelProvider.kt
+++ b/viewmodel/src/main/java/com/linecorp/lich/viewmodel/internal/DefaultLichViewModelProvider.kt
@@ -43,7 +43,9 @@ open class DefaultLichViewModelProvider : LichViewModelProvider {
         arguments: Bundle?
     ): T {
         // The key to use to identify the BridgeViewModel in a ViewModelStore.
-        val key = factory.javaClass.name
+        val key = "lich:" + requireNotNull(factory.javaClass.canonicalName) {
+            "ViewModelFactories cannot be local or anonymous classes."
+        }
 
         // We always create a BridgeViewModel object for ViewModelStores of Android Architecture Components.
         val bridgeViewModelFactory = BridgeViewModelFactory(savedStateRegistryOwner, arguments)


### PR DESCRIPTION
ViewModelFactories should always be declared as `object`.
So, its canonical class name must not be `null`.