### PR TITLE
Update LichFactoryDetector

### DIFF
--- a/static-analysis/src/main/java/com/linecorp/lich/static_analysis/detectors/LichFactoryDetector.kt
+++ b/static-analysis/src/main/java/com/linecorp/lich/static_analysis/detectors/LichFactoryDetector.kt
@@ -39,12 +39,12 @@ class LichFactoryDetector : Detector(), SourceCodeScanner {
         @JvmStatic
         val OBJECT_ISSUE: Issue = Issue.create(
             "FactoryShouldBeObject",
-            "It is better practice to implement factories using an *object* declaration.",
-            "Factories should be implemented by *object* declarations in order to avoid multiple " +
-                "instances of the same factory.",
+            "Factories should be implemented by *object declarations*.",
+            "In order to avoid multiple instances of the same factory, you should implement " +
+                "factories using an *object declaration*.",
             Category.CORRECTNESS,
             6,
-            Severity.WARNING,
+            Severity.ERROR,
             Implementation(LichFactoryDetector::class.java, Scope.JAVA_FILE_SCOPE)
         )
     }
@@ -127,7 +127,7 @@ class LichFactoryDetector : Detector(), SourceCodeScanner {
             OBJECT_ISSUE,
             node,
             getNameLocation(node),
-            "Factories generally should be implemented by *object* declarations."
+            "Factories should be implemented by *object declarations*."
         )
     }
 

--- a/static-analysis/src/main/java/com/linecorp/lich/static_analysis/detectors/LichFactoryDetector.kt
+++ b/static-analysis/src/main/java/com/linecorp/lich/static_analysis/detectors/LichFactoryDetector.kt
@@ -13,9 +13,7 @@ import com.android.tools.lint.detector.api.isKotlin
 import com.intellij.psi.PsiClassType
 import com.intellij.psi.impl.source.PsiClassReferenceType
 import com.linecorp.lich.static_analysis.extensions.findClosestParentByType
-import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
-import org.jetbrains.kotlin.psi.psiUtil.isAbstract
 import org.jetbrains.uast.UClass
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UTypeReferenceExpression
@@ -54,14 +52,12 @@ class LichFactoryDetector : Detector(), SourceCodeScanner {
     override fun applicableSuperClasses(): List<String> = Factory.qualifiedNames
 
     override fun visitClass(context: JavaContext, declaration: UClass) {
-        if (!isKotlin(declaration)) {
+        if (!isKotlin(declaration) || Factory.contains(declaration.qualifiedName)) {
             return
         }
         val declarationPsi = declaration.sourcePsi
-        if (declarationPsi !is KtObjectDeclaration) {
-            if (declarationPsi is KtClass && !declarationPsi.isAbstract()) {
-                context.reportObject(declaration)
-            }
+        if (declarationPsi !is KtObjectDeclaration || declarationPsi.isObjectLiteral()) {
+            context.reportObject(declaration)
         }
         val factorySupertypeDeclaration = declaration.findFactorySupertype() ?: return
         val factoryType = Factory.find(factorySupertypeDeclaration.getQualifiedName()) ?: return

--- a/static-analysis/src/main/java/com/linecorp/lich/static_analysis/detectors/LichFactoryDetector.kt
+++ b/static-analysis/src/main/java/com/linecorp/lich/static_analysis/detectors/LichFactoryDetector.kt
@@ -58,6 +58,10 @@ class LichFactoryDetector : Detector(), SourceCodeScanner {
         val declarationPsi = declaration.sourcePsi
         if (declarationPsi !is KtObjectDeclaration || declarationPsi.isObjectLiteral()) {
             context.reportObject(declaration)
+            return
+        }
+        if (!declarationPsi.isCompanion()) {
+            return
         }
         val factorySupertypeDeclaration = declaration.findFactorySupertype() ?: return
         val factoryType = Factory.find(factorySupertypeDeclaration.getQualifiedName()) ?: return

--- a/static-analysis/src/test/java/com/linecorp/lich/static_analysis/LichFactoryDetectorTest.kt
+++ b/static-analysis/src/test/java/com/linecorp/lich/static_analysis/LichFactoryDetectorTest.kt
@@ -16,13 +16,16 @@ class LichFactoryDetectorTest : LichLintDetectorTest(testAssetsFolder = "LichFac
         ).allowCompilationErrors(false)
             .run()
             .expect("""
-                src/com/linecorp/lich/component/ClassFactory.kt:5: Warning: Factories generally should be implemented by object declarations. [FactoryShouldBeObject]
-                class ClassFactory : ComponentFactory<ClassFactory>()
+                src/com/linecorp/lich/component/Api.kt:7: Error: Factories should be implemented by object declarations. [FactoryShouldBeObject]
+                class ClassFactory : ComponentFactory<Api>()
                       ~~~~~~~~~~~~
-                src/com/linecorp/lich/component/ClassFactory.kt:18: Error: This ComponentFactory's type argument should be TestBar. [InvalidTypeArgumentInFactory]
+                src/com/linecorp/lich/component/Api.kt:14: Error: Factories should be implemented by object declarations. [FactoryShouldBeObject]
+                val expressionFactory = object : ComponentFactory<Api>() {}
+                                        ~~~~~~
+                src/com/linecorp/lich/component/Api.kt:23: Error: This ComponentFactory's type argument should be TestBar. [InvalidTypeArgumentInFactory]
                     companion object : ComponentFactory<TestFoo>()
                                        ~~~~~~~~~~~~~~~~~~~~~~~~~
-                1 errors, 1 warnings
+                3 errors, 0 warnings
             """.trimIndent())
     }
 
@@ -36,13 +39,16 @@ class LichFactoryDetectorTest : LichLintDetectorTest(testAssetsFolder = "LichFac
         ).allowCompilationErrors(false)
             .run()
             .expect("""
-                src/com/linecorp/lich/viewmodel/TestFoo.kt:15: Warning: Factories generally should be implemented by object declarations. [FactoryShouldBeObject]
-                class ClassFactory : ViewModelFactory<ClassFactory>()
+                src/com/linecorp/lich/viewmodel/FooViewModel.kt:7: Error: Factories should be implemented by object declarations. [FactoryShouldBeObject]
+                class ClassFactory : ViewModelFactory<FooViewModel>()
                       ~~~~~~~~~~~~
-                src/com/linecorp/lich/viewmodel/TestFoo.kt:10: Error: This ViewModelFactory's type argument should be TestBar. [InvalidTypeArgumentInFactory]
+                src/com/linecorp/lich/viewmodel/FooViewModel.kt:14: Error: Factories should be implemented by object declarations. [FactoryShouldBeObject]
+                val expressionFactory = object : ViewModelFactory<FooViewModel>() {}
+                                        ~~~~~~
+                src/com/linecorp/lich/viewmodel/FooViewModel.kt:23: Error: This ViewModelFactory's type argument should be TestBar. [InvalidTypeArgumentInFactory]
                     companion object : ViewModelFactory<TestFoo>()
                                        ~~~~~~~~~~~~~~~~~~~~~~~~~
-                1 errors, 1 warnings
+                3 errors, 0 warnings
             """.trimIndent())
     }
 

--- a/static-analysis/src/test/test-assets/LichFactoryDetector/ComponentFactoryTest.kt
+++ b/static-analysis/src/test/test-assets/LichFactoryDetector/ComponentFactoryTest.kt
@@ -1,19 +1,29 @@
 package com.linecorp.lich.component
 
-// This should show a warning because a class is implementing a factory instead of an object
+interface Api
+
+// This should show an error because a class is implementing a factory instead of an object
 // declaration.
-class ClassFactory : ComponentFactory<ClassFactory>()
+class ClassFactory : ComponentFactory<Api>()
 
 // This is correct (lint shouldn't report this line) because an object declaration is
 // implementing the factory.
-object ObjectFactory : ComponentFactory<ClassFactory>()
+object ObjectFactory : ComponentFactory<Api>()
 
-class TestFoo : ComponentFactory() {
+// This should show an error because the factory is implemented using an *object expression*.
+val expressionFactory = object : ComponentFactory<Api>() {}
+
+class TestFoo {
     // This should be correct (lint shoudn't report this line)
     companion object : ComponentFactory<TestFoo>()
 }
 
-class TestBar : ComponentFactory() {
+class TestBar {
     // This should be wrong because TestBar's factory is creating TestFoo objects.
     companion object : ComponentFactory<TestFoo>()
+}
+
+class TestBaz {
+    // This should be correct because TestFooFactory is not a companion object.
+    object TestFooFactory : ComponentFactory<TestFoo>()
 }

--- a/static-analysis/src/test/test-assets/LichFactoryDetector/ViewModelFactoryTest.kt
+++ b/static-analysis/src/test/test-assets/LichFactoryDetector/ViewModelFactoryTest.kt
@@ -1,5 +1,18 @@
 package com.linecorp.lich.viewmodel
 
+class FooViewModel : AbstractViewModel()
+
+// This should show an error because a class is implementing a factory instead of an object
+// declaration.
+class ClassFactory : ViewModelFactory<FooViewModel>()
+
+// This is correct (lint shouldn't report this line) because an object declaration is
+// implementing the factory.
+object ObjectFactory : ViewModelFactory<FooViewModel>()
+
+// This should show an error because the factory is implemented using an *object expression*.
+val expressionFactory = object : ViewModelFactory<FooViewModel>() {}
+
 class TestFoo : AbstractViewModel() {
     // This should be correct (lint shoudn't report this line)
     companion object : ViewModelFactory<TestFoo>()
@@ -10,10 +23,7 @@ class TestBar : AbstractViewModel() {
     companion object : ViewModelFactory<TestFoo>()
 }
 
-// This should show a warning because a class is implementing a factory instead of an object
-// declaration.
-class ClassFactory : ViewModelFactory<ClassFactory>()
-
-// This is correct (lint shouldn't report this line) because an object declaration is
-// implementing the factory.
-object ObjecFactory : ViewModelFactory<ClassFactory>()
+class TestBaz : AbstractViewModel() {
+    // This should be correct because TestFooFactory is not a companion object.
+    object TestFooFactory : ViewModelFactory<TestFoo>()
+}


### PR DESCRIPTION
### Prohibit object expressions for factories.

In order to avoid multiple instances of the same factory, we also need to prohibit *object expressions* like this:
```kotlin
val fooFactory = object : ComponentFactory<Foo>() {
    override fun createComponent(context: Context): Foo = Foo()
}
```
Therefore, all factories except (Component|ViewModel)Factory themselves must be *object declarations*.

### Check the factory's type argument only if it is implemented as a companion object.

For example, the following code is less common but completely valid.
```kotlin
class FooUtil {
    object FooFactory : ComponentFactory<Foo>() {
        override fun createComponent(context: Context): Foo = FooImpl()
    }
}

val foo: Foo = context.getComponent(FooUtil.FooFactory)
```
Therefore, we should check the factory's type argument only if the factory is implemented as a companion object.

### Increase the severity of "FactoryShouldBeObject" to ERROR.