### PR TITLE
Remove `@Throws` annotation from suspending functions.

### DIFF
--- a/dagger_sample_app/src/main/java/com/linecorp/lich/sample/remote/CounterServiceClient.kt
+++ b/dagger_sample_app/src/main/java/com/linecorp/lich/sample/remote/CounterServiceClient.kt
@@ -34,7 +34,6 @@ class CounterServiceClient @Inject constructor(private val okHttpClient: OkHttpC
      * @return the initial value for the counter.
      * @throws IOException
      */
-    @Throws(IOException::class)
     suspend fun getInitialCounterValue(counterName: String): Int {
         Log.i("CounterServiceClient", "getInitialCounterValue: counterName = $counterName")
         // We use "jsonplaceholder.typicode.com" for a fake API server.

--- a/okhttp/README.md
+++ b/okhttp/README.md
@@ -16,7 +16,6 @@ function to send an HTTP request and receive its response.
 
 This is a sample code that fetches a content of the given URL as a `String`.
 ```kotlin
-@Throws(IOException::class)
 suspend fun fetchContentAsString(url: String): String {
     val request = Request.Builder().url(url).build()
     return okHttpClient.call(request) { response ->

--- a/okhttp/src/main/java/com/linecorp/lich/okhttp/OkHttpExtensions.kt
+++ b/okhttp/src/main/java/com/linecorp/lich/okhttp/OkHttpExtensions.kt
@@ -33,7 +33,6 @@ import kotlin.coroutines.resumeWithException
  *
  * This is a sample code that fetches a content of the given URL as `String`.
  * ```
- * @Throws(IOException::class)
  * suspend fun fetchContentAsString(url: String): String {
  *     val request = Request.Builder().url(url).build()
  *     return okHttpClient.call(request) { response ->
@@ -51,7 +50,6 @@ import kotlin.coroutines.resumeWithException
  * will be called from OkHttp's background threads.
  * @throws IOException
  */
-@Throws(IOException::class)
 suspend fun <T> OkHttpClient.call(request: Request, responseMapper: (Response) -> T): T =
     suspendCancellableCoroutine { cont ->
         val call = newCall(request)

--- a/sample_app/src/main/java/com/linecorp/lich/sample/remote/CounterServiceClient.kt
+++ b/sample_app/src/main/java/com/linecorp/lich/sample/remote/CounterServiceClient.kt
@@ -37,7 +37,6 @@ class CounterServiceClient private constructor(context: Context) {
      * @return the initial value for the counter.
      * @throws IOException
      */
-    @Throws(IOException::class)
     suspend fun getInitialCounterValue(counterName: String): Int {
         Log.i("CounterServiceClient", "getInitialCounterValue: counterName = $counterName")
         // We use "jsonplaceholder.typicode.com" for a fake API server.

--- a/thrift/README.md
+++ b/thrift/README.md
@@ -41,14 +41,12 @@ class FooServiceClient(private val okHttpClient: OkHttpClient) {
     private val handler: ThriftCallHandler<FooService.Client> =
         MyThriftCallHandler(FooService.Client.Factory(), "/foo")
 
-    @Throws(TException::class)
     suspend fun ping() =
         okHttpClient.callThrift(handler,
             { send_ping() },
             { recv_ping() }
         )
 
-    @Throws(TException::class)
     suspend fun callFoo(id: Long, name: String, param: FooParam): FooResponse =
         okHttpClient.callThrift(handler,
             { send_callFoo(id, name, param) },

--- a/thrift/src/main/java/com/linecorp/lich/thrift/ThriftExtensions.kt
+++ b/thrift/src/main/java/com/linecorp/lich/thrift/ThriftExtensions.kt
@@ -43,7 +43,6 @@ import java.io.IOException
  *     // See AbstractThriftCallHandler.
  *     private val handler: ThriftCallHandler<FooService.Client> = ...
  *
- *     @Throws(TException::class)
  *     suspend fun callFoo(id: Long, name: String, param: FooParam): FooResponse =
  *         okHttpClient.callThrift(handler,
  *             { send_callFoo(id, name, param) },
@@ -62,7 +61,6 @@ import java.io.IOException
  * @throws TException
  * @see AbstractThriftCallHandler
  */
-@Throws(TException::class)
 suspend fun <T : TServiceClient, R> OkHttpClient.callThrift(
     thriftCallHandler: ThriftCallHandler<T>,
     sendRequest: T.() -> Unit,


### PR DESCRIPTION
Suspending functions are never called from Java code, so `@Throws` annotations for suspending functions have no meaning.
Furthermore, recent lint checker now warns about calls to functions that have `@Throws(IOException)`. But, our suspending functions can be called from the main thread safely.