### PR TITLE
Add license information for Maven POM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,13 @@ def configurePublication(project, type) {
                         myPublication(MavenPublication) {
                             from components.java
                             artifact sourcesJar
+                            pom.licenses {
+                                license {
+                                    name = 'Apache-2.0'
+                                    url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                                    distribution = 'repo'
+                                }
+                            }
                         }
                     }
                 }
@@ -94,6 +101,13 @@ def configurePublication(project, type) {
                         myPublication(MavenPublication) {
                             from components.release
                             artifact sourcesJar
+                            pom.licenses {
+                                license {
+                                    name = 'Apache-2.0'
+                                    url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                                    distribution = 'repo'
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
I tried to use [Google Play OSS plugin](https://developers.google.com/android/guides/opensource) to show license notice on app.
But lich does not have license on POM, so it cannot show lich license.

https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:publications
https://maven.apache.org/pom.html#Licenses