### PR TITLE
Bump Robolectric to 4.5.1.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ buildscript {
         mockito                 : '2.28.2',
         mockitoKotlin           : '2.2.0',
         mockk                   : '1.10.0',
-        robolectric             : '4.4',
+        robolectric             : '4.5.1',
         dokka                   : '1.4.20',
     ]
     repositories {

--- a/component-debug/src/test/resources/robolectric.properties
+++ b/component-debug/src/test/resources/robolectric.properties
@@ -1,3 +1,0 @@
-# Robolectric currently doesn't support API 30, so we have to explicitly specify 29 as the target
-# sdk for now. Remove when no longer necessary.
-sdk=29

--- a/component-test-mockitokotlin/src/test/resources/robolectric.properties
+++ b/component-test-mockitokotlin/src/test/resources/robolectric.properties
@@ -1,3 +1,0 @@
-# Robolectric currently doesn't support API 30, so we have to explicitly specify 29 as the target
-# sdk for now. Remove when no longer necessary.
-sdk=29

--- a/component-test-mockk/src/test/resources/robolectric.properties
+++ b/component-test-mockk/src/test/resources/robolectric.properties
@@ -1,3 +1,0 @@
-# Robolectric currently doesn't support API 30, so we have to explicitly specify 29 as the target
-# sdk for now. Remove when no longer necessary.
-sdk=29

--- a/component-test/src/test/resources/robolectric.properties
+++ b/component-test/src/test/resources/robolectric.properties
@@ -1,3 +1,0 @@
-# Robolectric currently doesn't support API 30, so we have to explicitly specify 29 as the target
-# sdk for now. Remove when no longer necessary.
-sdk=29

--- a/component/src/test/resources/robolectric.properties
+++ b/component/src/test/resources/robolectric.properties
@@ -1,3 +1,0 @@
-# Robolectric currently doesn't support API 30, so we have to explicitly specify 29 as the target
-# sdk for now. Remove when no longer necessary.
-sdk=29

--- a/dagger_sample_app/src/test/resources/robolectric.properties
+++ b/dagger_sample_app/src/test/resources/robolectric.properties
@@ -1,3 +1,0 @@
-# Robolectric currently doesn't support API 30, so we have to explicitly specify 29 as the target
-# sdk for now. Remove when no longer necessary.
-sdk=29

--- a/sample_app/src/test/resources/robolectric.properties
+++ b/sample_app/src/test/resources/robolectric.properties
@@ -1,3 +1,0 @@
-# Robolectric currently doesn't support API 30, so we have to explicitly specify 29 as the target
-# sdk for now. Remove when no longer necessary.
-sdk=29


### PR DESCRIPTION
Now Robolectric supports Android API 30, so we remove robolectric.properties files.