### PR TITLE
Refactor internal logic of ViewModel creation.

### DIFF
--- a/viewmodel/src/main/java/com/linecorp/lich/viewmodel/ViewModelLazy.kt
+++ b/viewmodel/src/main/java/com/linecorp/lich/viewmodel/ViewModelLazy.kt
@@ -129,7 +129,6 @@ fun <T : AbstractViewModel> Fragment.navGraphViewModel(
     factory: ViewModelFactory<T>,
     @IdRes navGraphId: Int
 ): Lazy<T> = lazy(LazyThreadSafetyMode.NONE) {
-    NavHostFragment.findNavController(this).getBackStackEntry(navGraphId).let {
-        requireContext().getViewModel(it, it, factory, it.arguments)
-    }
+    NavHostFragment.findNavController(this).getBackStackEntry(navGraphId)
+        .getViewModel(requireContext(), factory)
 }

--- a/viewmodel/src/main/java/com/linecorp/lich/viewmodel/ViewModels.kt
+++ b/viewmodel/src/main/java/com/linecorp/lich/viewmodel/ViewModels.kt
@@ -23,6 +23,7 @@ import androidx.activity.ComponentActivity
 import androidx.annotation.MainThread
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelStoreOwner
+import androidx.navigation.NavBackStackEntry
 import androidx.savedstate.SavedStateRegistryOwner
 import com.linecorp.lich.viewmodel.internal.lichViewModelProvider
 
@@ -120,6 +121,19 @@ fun <T : AbstractViewModel> Fragment.getActivityViewModel(
     factory: ViewModelFactory<T>,
     arguments: Bundle? = requireActivity().intent?.extras
 ): T = requireActivity().getViewModel(factory, arguments)
+
+/**
+ * Returns an existing ViewModel or creates a new one, associated with this [NavBackStackEntry].
+ * You can use this ViewModel to pass UI-related data between destinations in a navigation graph.
+ *
+ * @param context a [Context].
+ * @param factory [ViewModelFactory] to create the ViewModel.
+ */
+@MainThread
+fun <T : AbstractViewModel> NavBackStackEntry.getViewModel(
+    context: Context,
+    factory: ViewModelFactory<T>
+): T = context.getViewModel(this, this, factory, this.arguments)
 
 @MainThread
 internal fun <T : AbstractViewModel> Context.getViewModel(

--- a/viewmodel/src/main/java/com/linecorp/lich/viewmodel/ViewModels.kt
+++ b/viewmodel/src/main/java/com/linecorp/lich/viewmodel/ViewModels.kt
@@ -22,10 +22,8 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.annotation.MainThread
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelStoreOwner
 import androidx.navigation.NavBackStackEntry
-import androidx.savedstate.SavedStateRegistryOwner
-import com.linecorp.lich.viewmodel.internal.lichViewModelProvider
+import com.linecorp.lich.viewmodel.internal.LichViewModels
 
 /**
  * Returns an existing ViewModel or creates a new one, associated with this Activity.
@@ -56,7 +54,7 @@ import com.linecorp.lich.viewmodel.internal.lichViewModelProvider
 fun <T : AbstractViewModel> ComponentActivity.getViewModel(
     factory: ViewModelFactory<T>,
     arguments: Bundle? = intent?.extras
-): T = getViewModel(this, this, factory, arguments)
+): T = LichViewModels.getViewModelWithExplicitArguments(this, this, this, factory, arguments)
 
 /**
  * Returns an existing ViewModel or creates a new one, associated with this Fragment.
@@ -87,7 +85,13 @@ fun <T : AbstractViewModel> ComponentActivity.getViewModel(
 fun <T : AbstractViewModel> Fragment.getViewModel(
     factory: ViewModelFactory<T>,
     arguments: Bundle? = this.arguments
-): T = requireContext().getViewModel(this, this, factory, arguments)
+): T = LichViewModels.getViewModelWithExplicitArguments(
+    requireContext(),
+    this,
+    this,
+    factory,
+    arguments
+)
 
 /**
  * Returns an existing ViewModel or creates a new one, associated with the Activity hosting this
@@ -133,18 +137,4 @@ fun <T : AbstractViewModel> Fragment.getActivityViewModel(
 fun <T : AbstractViewModel> NavBackStackEntry.getViewModel(
     context: Context,
     factory: ViewModelFactory<T>
-): T = context.getViewModel(this, this, factory, this.arguments)
-
-@MainThread
-internal fun <T : AbstractViewModel> Context.getViewModel(
-    viewModelStoreOwner: ViewModelStoreOwner,
-    savedStateRegistryOwner: SavedStateRegistryOwner,
-    factory: ViewModelFactory<T>,
-    arguments: Bundle?
-): T = lichViewModelProvider.getViewModel(
-    this,
-    viewModelStoreOwner,
-    savedStateRegistryOwner,
-    factory,
-    arguments
-)
+): T = LichViewModels.getViewModelWithDefaultArguments(context, this, this, factory)

--- a/viewmodel/src/main/java/com/linecorp/lich/viewmodel/internal/BridgeViewModel.kt
+++ b/viewmodel/src/main/java/com/linecorp/lich/viewmodel/internal/BridgeViewModel.kt
@@ -21,10 +21,10 @@ import androidx.lifecycle.ViewModel
 import com.linecorp.lich.viewmodel.AbstractViewModel
 
 /**
- * A class that bridges a [ViewModel] of Android Architecture Components and our [AbstractViewModel].
+ * A class that bridges an AndroidX [ViewModel] and Lich [AbstractViewModel].
  */
 @MainThread
-internal class BridgeViewModel(internal val savedStateHandle: SavedStateHandle) : ViewModel() {
+class BridgeViewModel(internal val savedStateHandle: SavedStateHandle) : ViewModel() {
 
     internal var viewModel: AbstractViewModel? = null
 

--- a/viewmodel/src/main/java/com/linecorp/lich/viewmodel/internal/DefaultLichViewModelProvider.kt
+++ b/viewmodel/src/main/java/com/linecorp/lich/viewmodel/internal/DefaultLichViewModelProvider.kt
@@ -16,13 +16,9 @@
 package com.linecorp.lich.viewmodel.internal
 
 import android.content.Context
-import android.os.Bundle
-import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
-import androidx.savedstate.SavedStateRegistryOwner
 import com.linecorp.lich.viewmodel.AbstractViewModel
 import com.linecorp.lich.viewmodel.ViewModelFactory
 
@@ -37,17 +33,15 @@ open class DefaultLichViewModelProvider : LichViewModelProvider {
     final override fun <T : AbstractViewModel> getViewModel(
         context: Context,
         viewModelStoreOwner: ViewModelStoreOwner,
-        savedStateRegistryOwner: SavedStateRegistryOwner,
-        factory: ViewModelFactory<T>,
-        arguments: Bundle?
+        bridgeViewModelFactory: ViewModelProvider.Factory,
+        factory: ViewModelFactory<T>
     ): T {
         // The key to use to identify the BridgeViewModel in a ViewModelStore.
         val key = "lich:" + requireNotNull(factory.javaClass.canonicalName) {
             "ViewModelFactories cannot be local or anonymous classes."
         }
 
-        // We always create a BridgeViewModel object for ViewModelStores of Android Architecture Components.
-        val bridgeViewModelFactory = BridgeViewModelFactory(savedStateRegistryOwner, arguments)
+        // First, we always create a BridgeViewModel object as an AndroidX ViewModel.
         val viewModelProvider = ViewModelProvider(viewModelStoreOwner, bridgeViewModelFactory)
         val bridgeViewModel = viewModelProvider.get(key, BridgeViewModel::class.java)
 
@@ -79,18 +73,6 @@ open class DefaultLichViewModelProvider : LichViewModelProvider {
         applicationContext: Context,
         savedStateHandle: SavedStateHandle
     ): T = factory.create(applicationContext, savedStateHandle)
-
-    private class BridgeViewModelFactory(
-        savedStateRegistryOwner: SavedStateRegistryOwner,
-        arguments: Bundle?
-    ) : AbstractSavedStateViewModelFactory(savedStateRegistryOwner, arguments) {
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(
-            key: String,
-            modelClass: Class<T>,
-            handle: SavedStateHandle
-        ): T = BridgeViewModel(handle) as T
-    }
 
     override fun getManager(applicationContext: Context): Any =
         throw UnsupportedOperationException()

--- a/viewmodel/src/main/java/com/linecorp/lich/viewmodel/internal/LichViewModelProvider.kt
+++ b/viewmodel/src/main/java/com/linecorp/lich/viewmodel/internal/LichViewModelProvider.kt
@@ -16,10 +16,9 @@
 package com.linecorp.lich.viewmodel.internal
 
 import android.content.Context
-import android.os.Bundle
 import androidx.annotation.MainThread
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
-import androidx.savedstate.SavedStateRegistryOwner
 import com.linecorp.lich.viewmodel.AbstractViewModel
 import com.linecorp.lich.viewmodel.ViewModelFactory
 import java.util.ServiceLoader
@@ -32,9 +31,8 @@ interface LichViewModelProvider {
     fun <T : AbstractViewModel> getViewModel(
         context: Context,
         viewModelStoreOwner: ViewModelStoreOwner,
-        savedStateRegistryOwner: SavedStateRegistryOwner,
-        factory: ViewModelFactory<T>,
-        arguments: Bundle?
+        bridgeViewModelFactory: ViewModelProvider.Factory,
+        factory: ViewModelFactory<T>
     ): T
 
     fun getManager(applicationContext: Context): Any

--- a/viewmodel/src/main/java/com/linecorp/lich/viewmodel/internal/LichViewModels.kt
+++ b/viewmodel/src/main/java/com/linecorp/lich/viewmodel/internal/LichViewModels.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linecorp.lich.viewmodel.internal
+
+import android.content.Context
+import android.os.Bundle
+import androidx.lifecycle.AbstractSavedStateViewModelFactory
+import androidx.lifecycle.HasDefaultViewModelProviderFactory
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.savedstate.SavedStateRegistryOwner
+import com.linecorp.lich.viewmodel.AbstractViewModel
+import com.linecorp.lich.viewmodel.ViewModelFactory
+
+/**
+ * Internal endpoint of Lich ViewModels.
+ */
+object LichViewModels {
+
+    fun <T : AbstractViewModel> getViewModelWithDefaultArguments(
+        context: Context,
+        viewModelStoreOwner: ViewModelStoreOwner,
+        hasDefaultViewModelProviderFactory: HasDefaultViewModelProviderFactory,
+        factory: ViewModelFactory<T>
+    ): T = lichViewModelProvider.getViewModel(
+        context,
+        viewModelStoreOwner,
+        hasDefaultViewModelProviderFactory.defaultViewModelProviderFactory,
+        factory
+    )
+
+    fun <T : AbstractViewModel> getViewModelWithExplicitArguments(
+        context: Context,
+        viewModelStoreOwner: ViewModelStoreOwner,
+        savedStateRegistryOwner: SavedStateRegistryOwner,
+        factory: ViewModelFactory<T>,
+        arguments: Bundle?
+    ): T = lichViewModelProvider.getViewModel(
+        context,
+        viewModelStoreOwner,
+        BridgeViewModelFactory(savedStateRegistryOwner, arguments),
+        factory
+    )
+
+    private class BridgeViewModelFactory(
+        savedStateRegistryOwner: SavedStateRegistryOwner,
+        arguments: Bundle?
+    ) : AbstractSavedStateViewModelFactory(savedStateRegistryOwner, arguments) {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(
+            key: String,
+            modelClass: Class<T>,
+            handle: SavedStateHandle
+        ): T = BridgeViewModel(handle) as T
+    }
+}


### PR DESCRIPTION
- If creating a ViewModel with the default arguments, use HasDefaultViewModelProviderFactory interface.
- Add `NavBackStackEntry.getViewModel()` extension function.