### PR TITLE
Update mockito-kotlin to 3.2.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ buildscript {
         thrift                  : '0.13.0',
         dexmaker                : '2.28.1',
         mockito                 : '3.10.0',
-        mockitoKotlin           : '2.2.0',
+        mockitoKotlin           : '3.2.0',
         mockk                   : '1.11.0',
         robolectric             : '4.5.1',
         dokka                   : '1.4.32',

--- a/component-test-mockitokotlin/build.gradle
+++ b/component-test-mockitokotlin/build.gradle
@@ -35,12 +35,12 @@ android {
 dependencies {
     api project(':component-test')
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
-    compileOnly "com.nhaarman.mockitokotlin2:mockito-kotlin:${versions.mockitoKotlin}"
+    compileOnly "org.mockito.kotlin:mockito-kotlin:${versions.mockitoKotlin}"
 
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlin}"
     testImplementation "androidx.test:runner:${versions.androidxTestRunner}"
     testImplementation "androidx.test.ext:junit:${versions.androidxTestJunit}"
     testImplementation "org.mockito:mockito-inline:${versions.mockito}"
-    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:${versions.mockitoKotlin}"
+    testImplementation "org.mockito.kotlin:mockito-kotlin:${versions.mockitoKotlin}"
     testImplementation "org.robolectric:robolectric:${versions.robolectric}"
 }

--- a/component-test-mockitokotlin/src/main/java/com/linecorp/lich/component/test/mockitokotlin/Mocking.kt
+++ b/component-test-mockitokotlin/src/main/java/com/linecorp/lich/component/test/mockitokotlin/Mocking.kt
@@ -18,9 +18,9 @@ package com.linecorp.lich.component.test.mockitokotlin
 import com.linecorp.lich.component.ComponentFactory
 import com.linecorp.lich.component.test.getRealComponent
 import com.linecorp.lich.component.test.setMockComponent
-import com.nhaarman.mockitokotlin2.KStubbing
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.spy
+import org.mockito.kotlin.KStubbing
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
 
 /**
  * Creates a mock component allowing for immediate stubbing, and sets the mock for [factory].

--- a/component-test-mockitokotlin/src/test/java/com/linecorp/lich/component/test/mockitokotlin/MockingTest.kt
+++ b/component-test-mockitokotlin/src/test/java/com/linecorp/lich/component/test/mockitokotlin/MockingTest.kt
@@ -20,11 +20,11 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.linecorp.lich.component.getComponent
 import com.linecorp.lich.component.test.clearMockComponent
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.verify
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verify
 import kotlin.test.assertEquals
 import kotlin.test.assertNotSame
 import kotlin.test.assertSame

--- a/component/README.md
+++ b/component/README.md
@@ -46,7 +46,7 @@ dependencies {
 For unit-testing, the `component-test` module provides [AndroidX Test](https://developer.android.com/training/testing/set-up-project)
 support. (For Robolectric, see also [this document](http://robolectric.org/androidx_test/).)
 In addition, helper functions to work with [MockK](https://mockk.io/) or
-[Mockito-Kotlin](https://github.com/nhaarman/mockito-kotlin) are also available.
+[Mockito-Kotlin](https://github.com/mockito/mockito-kotlin) are also available.
 
 If you are using [MockK](https://mockk.io/), add the following dependencies:
 
@@ -65,7 +65,7 @@ dependencies {
 }
 ```
 
-If you are using [Mockito-Kotlin](https://github.com/nhaarman/mockito-kotlin), add the following
+If you are using [Mockito-Kotlin](https://github.com/mockito/mockito-kotlin), add the following
 dependencies instead:
 
 ```groovy
@@ -74,14 +74,14 @@ dependencies {
     testImplementation 'androidx.test:runner:x.x.x'
     testImplementation 'androidx.test.ext:junit:x.x.x'
     testImplementation 'org.mockito:mockito-inline:x.x.x'
-    testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:x.x.x'
+    testImplementation 'org.mockito.kotlin:mockito-kotlin:x.x.x'
     testImplementation 'org.robolectric:robolectric:x.x'
 
     androidTestImplementation 'com.linecorp.lich:component-test-mockitokotlin:x.x.x'
     androidTestImplementation 'androidx.test:runner:x.x.x'
     androidTestImplementation 'androidx.test.ext:junit:x.x.x'
     androidTestImplementation 'org.mockito:mockito-android:x.x.x'
-    androidTestImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:x.x.x'
+    androidTestImplementation 'org.mockito.kotlin:mockito-kotlin:x.x.x'
 }
 ```
 
@@ -413,7 +413,7 @@ See also
 [CounterUseCaseTest](../sample_app/src/test/java/com/linecorp/lich/sample/mvvm/CounterUseCaseTest.kt).
 
 The [mockComponent](../component-test-mockitokotlin/src/main/java/com/linecorp/lich/component/test/mockitokotlin/Mocking.kt)
-function is also available for [Mockito-Kotlin](https://github.com/nhaarman/mockito-kotlin).
+function is also available for [Mockito-Kotlin](https://github.com/mockito/mockito-kotlin).
 Here is an example using Mockito-Kotlin.
 
 ```kotlin

--- a/viewmodel-test-mockitokotlin/build.gradle
+++ b/viewmodel-test-mockitokotlin/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.kotlinCoroutines}"
     implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:${versions.androidxLifecycle}"
-    compileOnly "com.nhaarman.mockitokotlin2:mockito-kotlin:${versions.mockitoKotlin}"
+    compileOnly "org.mockito.kotlin:mockito-kotlin:${versions.mockitoKotlin}"
 
     androidTestImplementation project(':savedstate')
     kaptAndroidTest project(':savedstate-compiler')
@@ -41,5 +41,5 @@ dependencies {
     androidTestImplementation "androidx.test:runner:${versions.androidxTestRunner}"
     androidTestImplementation "androidx.test.ext:junit:${versions.androidxTestJunit}"
     androidTestImplementation "org.mockito:mockito-android:${versions.mockito}"
-    androidTestImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:${versions.mockitoKotlin}"
+    androidTestImplementation "org.mockito.kotlin:mockito-kotlin:${versions.mockitoKotlin}"
 }

--- a/viewmodel-test-mockitokotlin/src/androidTest/java/com/linecorp/lich/viewmodel/test/mockitokotlin/MockingTest.kt
+++ b/viewmodel-test-mockitokotlin/src/androidTest/java/com/linecorp/lich/viewmodel/test/mockitokotlin/MockingTest.kt
@@ -18,13 +18,13 @@ package com.linecorp.lich.viewmodel.test.mockitokotlin
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.linecorp.lich.viewmodel.test.clearAllMockViewModels
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.only
-import com.nhaarman.mockitokotlin2.verify
 import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.never
+import org.mockito.kotlin.only
+import org.mockito.kotlin.verify
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertSame

--- a/viewmodel-test-mockitokotlin/src/main/java/com/linecorp/lich/viewmodel/test/mockitokotlin/Mocking.kt
+++ b/viewmodel-test-mockitokotlin/src/main/java/com/linecorp/lich/viewmodel/test/mockitokotlin/Mocking.kt
@@ -19,9 +19,9 @@ import com.linecorp.lich.viewmodel.AbstractViewModel
 import com.linecorp.lich.viewmodel.ViewModelFactory
 import com.linecorp.lich.viewmodel.test.MockViewModelHandle
 import com.linecorp.lich.viewmodel.test.createRealViewModel
-import com.nhaarman.mockitokotlin2.KStubbing
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.spy
+import org.mockito.kotlin.KStubbing
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
 
 /**
  * Sets mock ViewModel factory for [factory]. The mock factory supports immediate stubbing.

--- a/viewmodel/README.md
+++ b/viewmodel/README.md
@@ -33,7 +33,7 @@ dependencies {
 ```
 
 The above code uses [MockK](https://mockk.io/) as a mocking library.
-If you prefer [Mockito-Kotlin](https://github.com/nhaarman/mockito-kotlin) over MockK, you can specify the following instead.
+If you prefer [Mockito-Kotlin](https://github.com/mockito/mockito-kotlin) over MockK, you can specify the following instead.
 
 ```groovy
 dependencies {
@@ -43,14 +43,14 @@ dependencies {
     testImplementation 'androidx.test:runner:x.x.x'
     testImplementation 'androidx.test.ext:junit:x.x.x'
     testImplementation 'org.mockito:mockito-inline:x.x.x'
-    testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:x.x.x'
+    testImplementation 'org.mockito.kotlin:mockito-kotlin:x.x.x'
     testImplementation 'org.robolectric:robolectric:x.x'
 
     androidTestImplementation 'com.linecorp.lich:viewmodel-test-mockitokotlin:x.x.x'
     androidTestImplementation 'androidx.test:runner:x.x.x'
     androidTestImplementation 'androidx.test.ext:junit:x.x.x'
     androidTestImplementation 'org.mockito:mockito-android:x.x.x'
-    androidTestImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:x.x.x'
+    androidTestImplementation 'org.mockito.kotlin:mockito-kotlin:x.x.x'
 }
 ```
 
@@ -205,7 +205,7 @@ See also
 in the sample_app module.
 
 The [mockViewModel](../viewmodel-test-mockitokotlin/src/main/java/com/linecorp/lich/viewmodel/test/mockitokotlin/Mocking.kt)
-function is also available for [Mockito-Kotlin](https://github.com/nhaarman/mockito-kotlin).
+function is also available for [Mockito-Kotlin](https://github.com/mockito/mockito-kotlin).
 Here is an example using Mockito-Kotlin.
 
 ```kotlin


### PR DESCRIPTION
- Now, mockito-kotlin is hosted on https://github.com/mockito/, and its package name was changed from `com.nhaarman.mockitokotlin2` to `org.mockito.kotlin`.