### PR TITLE
Remove the hack for avoiding '/META-INF/*.kotlin_module' conflicts.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,15 +65,6 @@ nexusStaging {
     stagingProfileId = '465b0f4eecd582'
 }
 
-subprojects {
-    // Avoid '/META-INF/*.kotlin_module' conflicts.
-    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-        kotlinOptions {
-            freeCompilerArgs += ['-module-name', "com_linecorp_lich_${project.name}"]
-        }
-    }
-}
-
 task clean(type: Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
This hack is no longer needed for AGP 7.0(?) or later.