### PR TITLE
Add dependency constraints for lifecycle-viewmodel-ktx.

### DIFF
--- a/sample-app/app/build.gradle
+++ b/sample-app/app/build.gradle
@@ -43,7 +43,6 @@ dependencies {
     implementation libs.androidx.fragment.ktx
     implementation libs.androidx.lifecycle.livedata.ktx
     implementation libs.androidx.lifecycle.runtime.ktx
-    implementation libs.androidx.lifecycle.viewmodel.ktx // https://github.com/line/lich/issues/114
     implementation libs.androidx.navigation.fragment.ktx
     implementation libs.androidx.navigation.ui.ktx
     implementation libs.okhttp

--- a/savedstate/build.gradle
+++ b/savedstate/build.gradle
@@ -26,9 +26,14 @@ dependencies {
     api libs.androidx.lifecycle.viewmodel.savedstate
     compileOnly libs.androidx.fragment
     lintPublish project(':static-analysis')
+    // https://github.com/line/lich/issues/114
+    constraints {
+        implementation(libs.androidx.lifecycle.viewmodel.ktx) {
+            because 'lifecycle-viewmodel-ktx:2.3 conflicts with lifecycle-viewmodel:2.4+'
+        }
+    }
 
     kspAndroidTest project(':savedstate-compiler')
     androidTestImplementation libs.bundles.test.instrumentation
     androidTestImplementation libs.androidx.fragment.ktx
-    androidTestImplementation libs.androidx.lifecycle.viewmodel.ktx // https://github.com/line/lich/issues/114
 }

--- a/viewmodel-test-mockitokotlin/build.gradle
+++ b/viewmodel-test-mockitokotlin/build.gradle
@@ -30,7 +30,6 @@ dependencies {
     kspAndroidTest project(':savedstate-compiler')
     androidTestImplementation libs.bundles.test.instrumentation
     androidTestImplementation libs.androidx.fragment.ktx
-    androidTestImplementation libs.androidx.lifecycle.viewmodel.ktx // https://github.com/line/lich/issues/114
     androidTestImplementation libs.mockito.android
     androidTestImplementation libs.mockito.kotlin
 }

--- a/viewmodel-test-mockk/build.gradle
+++ b/viewmodel-test-mockk/build.gradle
@@ -30,6 +30,5 @@ dependencies {
     kspAndroidTest project(':savedstate-compiler')
     androidTestImplementation libs.bundles.test.instrumentation
     androidTestImplementation libs.androidx.fragment.ktx
-    androidTestImplementation libs.androidx.lifecycle.viewmodel.ktx // https://github.com/line/lich/issues/114
     androidTestImplementation libs.mockk.android
 }

--- a/viewmodel-test/build.gradle
+++ b/viewmodel-test/build.gradle
@@ -30,5 +30,4 @@ dependencies {
     kspAndroidTest project(':savedstate-compiler')
     androidTestImplementation libs.bundles.test.instrumentation
     androidTestImplementation libs.androidx.fragment.ktx
-    androidTestImplementation libs.androidx.lifecycle.viewmodel.ktx // https://github.com/line/lich/issues/114
 }

--- a/viewmodel/build.gradle
+++ b/viewmodel/build.gradle
@@ -28,10 +28,15 @@ dependencies {
     compileOnly libs.androidx.fragment
     compileOnly libs.androidx.navigation.fragment
     lintPublish project(':static-analysis')
+    // https://github.com/line/lich/issues/114
+    constraints {
+        implementation(libs.androidx.lifecycle.viewmodel.ktx) {
+            because 'lifecycle-viewmodel-ktx:2.3 conflicts with lifecycle-viewmodel:2.4+'
+        }
+    }
 
     androidTestImplementation project(':savedstate')
     kspAndroidTest project(':savedstate-compiler')
     androidTestImplementation libs.bundles.test.instrumentation
     androidTestImplementation libs.androidx.fragment.ktx
-    androidTestImplementation libs.androidx.lifecycle.viewmodel.ktx // https://github.com/line/lich/issues/114
 }


### PR DESCRIPTION
Use dependency constraints to fix #114.
cf. https://docs.gradle.org/current/userguide/dependency_constraints.html

Fixes #114 